### PR TITLE
Add support for Firefox

### DIFF
--- a/background.js
+++ b/background.js
@@ -7,7 +7,7 @@ var currentTab = "";
 // Fire when user clicks icon
 chrome.browserAction.onClicked.addListener(function (tab) {
 	var host = tab.url.match(/^[\w-]+:\/*\[?([\w\.:-]+)\]?(?::\d+)?/)[0];
-	
+
 	if (hasClicked) {
 		chrome.tabs.create({ url: "https://securityheaders.io/?hide=on&source=chromeplugin&q=" + host });
 	}
@@ -24,10 +24,12 @@ chrome.browserAction.onClicked.addListener(function (tab) {
 });
 
 // Handle tab switching
-chrome.tabs.onActivated.addListener(function (tabId, changeInfo, tab) {
+chrome.tabs.onActivated.addListener(function ({ tabId }) {
     setDefault();
-    currentURL = tab.url;
     currentTab = tabId;
+    chrome.tabs.get(tabId, function (tab) {
+        currentURL = tab.url;
+    });
 });
 
 // Handle URL changes

--- a/manifest.json
+++ b/manifest.json
@@ -3,6 +3,11 @@
     "short_name": "securityheaders.io",
     "description": "Click to show the score for the current page. Click again to show the full report on our site.",
     "version": "1.0",
+    "applications": {
+        "gecko": {
+            "id": "score@securityheaders.io"
+        }
+    },
     "permissions": ["tabs", "https://securityheaders.io/*"],
     "background": {
         "page": "background.html"
@@ -14,7 +19,7 @@
         "default_title": "SecurityHeaders.io"
     },
     "manifest_version": 2,
-    "icons": { 
+    "icons": {
         "48": "icons/security-headers-icon-48.png",
         "128": "icons/security-headers-icon-128.png" }
 }


### PR DESCRIPTION
Upcoming versions of Firefox are adding support for the [extension APIs](https://developer.mozilla.org/en-US/Add-ons/WebExtensions) as Chrome. With some small changes, we can reuse this add-on in Firefox too.

There is one dilemma though: at the moment, Firefox needs an `applications` section added to the manifest.json, but this triggers an error in Chrome.

One way we can solve this is by adding a build step, so the manifest is modified for the Firefox version only. What do you think?
